### PR TITLE
Wmt22 language support

### DIFF
--- a/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
+++ b/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
@@ -5,13 +5,12 @@ from hu_nmt.data_augmentator.dependency_parsers.spacy_dependency_parser import S
 
 class DependencyParserFactory:
     dep_parsers = {
-        'en': lambda: StanzaDependencyParser(lang='en'),
-        'de': lambda: StanzaDependencyParser(lang='de'),
+        'en': lambda: StanzaDependencyParser(lang='en', processors='tokenize, pos, lemma, depparse'),
+        'ja': lambda: StanzaDependencyParser(lang='ja', processors='tokenize, pos, lemma, depparse'),
+        'de': lambda: StanzaDependencyParser(lang='de', processors='tokenize, mwt, pos, lemma, depparse'),
+        'uk': lambda: StanzaDependencyParser(lang='uk', processors='tokenize, mwt, pos, lemma, depparse'),
+        'fr': lambda: StanzaDependencyParser(lang='fr', processors='tokenize, mwt, pos, lemma, depparse'),
         'hu': lambda: SpacyDependencyParser(lang='hu'),
-        'uk': lambda: StanzaDependencyParser(lang='uk'),
-        'fr': lambda: StanzaDependencyParser(lang='fr'),
-        'ja': lambda: StanzaDependencyParser(lang='ja'),
-
     }
     @classmethod
     def get_dependency_parser(cls, lang_code) -> DependencyParserBase:

--- a/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
+++ b/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
@@ -9,8 +9,7 @@ class DependencyParserFactory:
         'ja': lambda: StanzaDependencyParser(lang='ja', processors='tokenize, pos, lemma, depparse'),
         'hr': lambda: StanzaDependencyParser(lang='hr', processors='tokenize, pos, lemma, depparse'),
         'ru': lambda: StanzaDependencyParser(lang='ru', processors='tokenize, pos, lemma, depparse'),
-        # Cannot load it, need to look into it
-        # 'cz': lambda: StanzaDependencyParser(lang='cz', processors='tokenize, pos, lemma, depparse'),
+        'cs': lambda: StanzaDependencyParser(lang='cs', processors='tokenize, mwt, pos, lemma, depparse'),
         'de': lambda: StanzaDependencyParser(lang='de', processors='tokenize, mwt, pos, lemma, depparse'),
         'uk': lambda: StanzaDependencyParser(lang='uk', processors='tokenize, mwt, pos, lemma, depparse'),
         'fr': lambda: StanzaDependencyParser(lang='fr', processors='tokenize, mwt, pos, lemma, depparse'),

--- a/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
+++ b/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
@@ -7,9 +7,12 @@ class DependencyParserFactory:
     dep_parsers = {
         'en': lambda: StanzaDependencyParser(lang='en'),
         'de': lambda: StanzaDependencyParser(lang='de'),
-        'hu': lambda: SpacyDependencyParser(lang='hu')
-    }
+        'hu': lambda: SpacyDependencyParser(lang='hu'),
+        'uk': lambda: StanzaDependencyParser(lang='uk'),
+        'fr': lambda: StanzaDependencyParser(lang='fr'),
+        'ja': lambda: StanzaDependencyParser(lang='ja'),
 
+    }
     @classmethod
     def get_dependency_parser(cls, lang_code) -> DependencyParserBase:
         return cls.dep_parsers[lang_code]()

--- a/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
+++ b/src/hu_nmt/data_augmentator/dependency_parsers/dependency_parser_factory.py
@@ -7,6 +7,10 @@ class DependencyParserFactory:
     dep_parsers = {
         'en': lambda: StanzaDependencyParser(lang='en', processors='tokenize, pos, lemma, depparse'),
         'ja': lambda: StanzaDependencyParser(lang='ja', processors='tokenize, pos, lemma, depparse'),
+        'hr': lambda: StanzaDependencyParser(lang='hr', processors='tokenize, pos, lemma, depparse'),
+        'ru': lambda: StanzaDependencyParser(lang='ru', processors='tokenize, pos, lemma, depparse'),
+        # Cannot load it, need to look into it
+        # 'cz': lambda: StanzaDependencyParser(lang='cz', processors='tokenize, pos, lemma, depparse'),
         'de': lambda: StanzaDependencyParser(lang='de', processors='tokenize, mwt, pos, lemma, depparse'),
         'uk': lambda: StanzaDependencyParser(lang='uk', processors='tokenize, mwt, pos, lemma, depparse'),
         'fr': lambda: StanzaDependencyParser(lang='fr', processors='tokenize, mwt, pos, lemma, depparse'),

--- a/src/hu_nmt/data_augmentator/dependency_parsers/stanza_dependency_parser.py
+++ b/src/hu_nmt/data_augmentator/dependency_parsers/stanza_dependency_parser.py
@@ -14,13 +14,13 @@ ROOT_KEY = 'root_0'
 
 
 class StanzaDependencyParser(DependencyParserBase):
-    def __init__(self, lang):
+    def __init__(self, lang, processors):
         try:
-            self.nlp_pipeline = stanza.Pipeline(lang=lang, processors='tokenize,mwt,pos,lemma,depparse')
+            self.nlp_pipeline = stanza.Pipeline(lang=lang, processors=processors)
         except LanguageNotDownloadedError as e:
             log.info(f'Could not find Stanza model for lang: {lang}. Downloading it now...')
             stanza.download(lang)
-            self.nlp_pipeline = stanza.Pipeline(lang=lang, processors='tokenize,mwt,pos,lemma,depparse')
+            self.nlp_pipeline = stanza.Pipeline(lang=lang, processors=processors)
         super().__init__(self.nlp_pipeline, use_multiprocessing=os.getenv('USE_MULTIPROCESSING', False))
 
     @staticmethod

--- a/src/hu_nmt/data_augmentator/dependency_parsers/stanza_dependency_parser.py
+++ b/src/hu_nmt/data_augmentator/dependency_parsers/stanza_dependency_parser.py
@@ -3,6 +3,7 @@ from typing import List
 
 import networkx as nx
 import stanza
+from stanza.pipeline.core import LanguageNotDownloadedError
 
 from hu_nmt.data_augmentator.base.depedency_parser_base import DependencyParserBase, NodeRelationship
 from hu_nmt.data_augmentator.utils.logger import get_logger
@@ -14,7 +15,12 @@ ROOT_KEY = 'root_0'
 
 class StanzaDependencyParser(DependencyParserBase):
     def __init__(self, lang):
-        self.nlp_pipeline = stanza.Pipeline(lang=lang, processors='tokenize,mwt,pos,lemma,depparse')
+        try:
+            self.nlp_pipeline = stanza.Pipeline(lang=lang, processors='tokenize,mwt,pos,lemma,depparse')
+        except LanguageNotDownloadedError as e:
+            log.info(f'Could not find Stanza model for lang: {lang}. Downloading it now...')
+            stanza.download(lang)
+            self.nlp_pipeline = stanza.Pipeline(lang=lang, processors='tokenize,mwt,pos,lemma,depparse')
         super().__init__(self.nlp_pipeline, use_multiprocessing=os.getenv('USE_MULTIPROCESSING', False))
 
     @staticmethod

--- a/src/hu_nmt/data_augmentator/entrypoints/precompute_en_dependency_trees.py
+++ b/src/hu_nmt/data_augmentator/entrypoints/precompute_en_dependency_trees.py
@@ -1,6 +1,7 @@
 import click
+
+from hu_nmt.data_augmentator.dependency_parsers.dependency_parser_factory import DependencyParserFactory
 from hu_nmt.data_augmentator.utils.logger import get_logger
-from hu_nmt.data_augmentator.dependency_parsers.stanza_dependency_parser import StanzaDependencyParser
 
 log = get_logger(__name__)
 
@@ -10,7 +11,7 @@ log = get_logger(__name__)
 @click.argument('dep_tree_output_path')
 @click.argument('file_batch_size')
 def main(data_input_path, dep_tree_output_path, file_batch_size):
-    eng_dep_parser = StanzaDependencyParser(lang='en')
+    eng_dep_parser = DependencyParserFactory.get_dependency_parser('en')
     eng_dep_parser.file_to_serialized_dep_graph_files(data_input_path, dep_tree_output_path, int(file_batch_size))
 
 

--- a/src/hu_nmt/data_augmentator/entrypoints/run_subj_obj_augmentation.py
+++ b/src/hu_nmt/data_augmentator/entrypoints/run_subj_obj_augmentation.py
@@ -1,6 +1,7 @@
 import click
 from tqdm import tqdm
 from hu_nmt.data_augmentator.augmentators.subject_object_augmentator import SubjectObjectAugmentator
+from hu_nmt.data_augmentator.dependency_parsers.dependency_parser_factory import DependencyParserFactory
 from hu_nmt.data_augmentator.dependency_parsers.stanza_dependency_parser import StanzaDependencyParser
 from hu_nmt.data_augmentator.dependency_parsers.spacy_dependency_parser import SpacyDependencyParser
 from hu_nmt.data_augmentator.utils.logger import get_logger
@@ -18,7 +19,8 @@ log = get_logger(__name__)
 @click.argument('augmentation_output_path')
 @click.argument('augmented_data_ratio')
 @click.option('--use_filters', is_flag=True, default=False, help='Use filters after the augmentation')
-@click.option('--filter_quantile', default=0.0, help='Quantile to use when filtering with cosine similarity. (Throw away anything below this quantile.)')
+@click.option('--filter_quantile', default=0.0,
+              help='Quantile to use when filtering with cosine similarity. (Throw away anything below this quantile.)')
 @click.option('--src_model_path', default='', help='Path to model to translate the source sentences with')
 @click.option('--tgt_model_path', default='', help='Path to model to translate the target sentences with')
 @click.option('--sp_model_path', default='', help='Sentencepiece model path')
@@ -26,12 +28,11 @@ log = get_logger(__name__)
 @click.option('--output_format', default='basic', help='Supported output formats: basic (default), tsv')
 @click.option('--save_original/--dont_save_original', default=False)
 @click.option('--separate_augmentation', default=False)
-
 def main(src_language, tgt_language, src_data_folder, tgt_data_folder, augmentation_output_path,
          augmented_data_ratio, use_filters, filter_quantile, src_model_path, tgt_model_path, sp_model_path,
          filter_batch_size, output_format, save_original, separate_augmentation):
     dep_parsers = {
-        'en': StanzaDependencyParser(lang='en'),
+        'en': DependencyParserFactory.get_dependency_parser('en'),
         'hu': SpacyDependencyParser(lang='hu')
     }
 
@@ -42,7 +43,8 @@ def main(src_language, tgt_language, src_data_folder, tgt_data_folder, augmentat
 
     filters = []
     if use_filters:
-        filters.append(BleuFilter(filter_quantile, src_model_path, tgt_model_path, sp_model_path, tgt_language, filter_batch_size))
+        filters.append(
+            BleuFilter(filter_quantile, src_model_path, tgt_model_path, sp_model_path, tgt_language, filter_batch_size))
     augmentator = SubjectObjectAugmentator(None, None, augmented_data_ratio, random_seed=15, filters=filters,
                                            output_path=augmentation_output_path, output_format=output_format,
                                            save_original=save_original, separate_augmentation=separate_augmentation)
@@ -75,4 +77,4 @@ if __name__ == '__main__':
     # $4 15
 
     # During hu-nmt use
-    # /home1/hu-nmt/data/Hunglish2/augmented/dep_trees/en /home1/hu-nmt/data/Hunglish2/augmented/dep_trees/hu /home1/hu-nmt/data/Hunglish2/augmented/generated-0.25 0.25
+    #  /home1/hu-nmt/data/Hunglish2/augmented/dep_trees/en /home1/hu-nmt/data/Hunglish2/augmented/dep_trees/hu /home1/hu-nmt/data/Hunglish2/augmented/generated-0.25 0.25

--- a/src/hu_nmt/test/dependency_graph_wrapper_test.py
+++ b/src/hu_nmt/test/dependency_graph_wrapper_test.py
@@ -1,8 +1,8 @@
 import os
 import unittest
 
+from hu_nmt.data_augmentator.dependency_parsers.dependency_parser_factory import DependencyParserFactory
 from hu_nmt.data_augmentator.wrapper.dependency_graph_wrapper import DependencyGraphWrapper
-from hu_nmt.data_augmentator.dependency_parsers.stanza_dependency_parser import StanzaDependencyParser
 
 dirname = os.path.dirname(__file__)
 
@@ -12,7 +12,7 @@ class DependencyGraphWrapperTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         sentence = 'Helen took her dog for a walk in the woods.'
-        cls.eng_dep_parser = StanzaDependencyParser(lang='en')
+        cls.eng_dep_parser = DependencyParserFactory.get_dependency_parser('en')
         graph = cls.eng_dep_parser.sentence_to_dep_parse_tree(sentence)
         cls.dep_graph_wrapper = DependencyGraphWrapper(graph)
 

--- a/src/hu_nmt/test/subject_object_augmentator_test.py
+++ b/src/hu_nmt/test/subject_object_augmentator_test.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from hu_nmt.data_augmentator.augmentators.subject_object_augmentator import SubjectObjectAugmentator
-from hu_nmt.data_augmentator.dependency_parsers.stanza_dependency_parser import StanzaDependencyParser
+from hu_nmt.data_augmentator.dependency_parsers.dependency_parser_factory import DependencyParserFactory
 from hu_nmt.data_augmentator.dependency_parsers.spacy_dependency_parser import SpacyDependencyParser
 from hu_nmt.data_augmentator.utils.translation_graph import TranslationGraph
 from hu_nmt.data_augmentator.wrapper.dependency_graph_wrapper import DependencyGraphWrapper
@@ -13,7 +13,7 @@ class SubjectObjectAugmentatorTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
-        cls.english_dep_parser = StanzaDependencyParser(lang='en')
+        cls.english_dep_parser = DependencyParserFactory.get_dependency_parser('en')
         cls.hungarian_dep_parser = SpacyDependencyParser(lang='hu')
 
     def test_subject_object_augmentator_setup(self):


### PR DESCRIPTION
With this PR, we are now able to run almost all experiments on the [WMT2022 general task datasets](https://statmt.org/wmt22/translation-task.html):

The ones we can run after merging this PR:
**High-resource:**
- en-de 
- en-cs
- en-ru

**Medium-resource:**
- fr-de
- uk-en
- en-ja

**Low-resource:**
- en>hr
- uk-cs

en-zh is the only one left that we could add, but we need to figure out if it's traditional or simplified (or both and we need transliteration) + I would focus on the medium- and low-resource language pairs at first.


